### PR TITLE
Handle missing RC tags in scanner output script

### DIFF
--- a/.github/workflows/scripts/scanner-output-release-versions.sh
+++ b/.github/workflows/scripts/scanner-output-release-versions.sh
@@ -25,13 +25,13 @@ tag() {
     fi
     local re
     re="${ver//./\\.}"
-    re="^$re-rc\.[0-9]+|${re%.*}.x$"
+    re="^$re-rc\\.[0-9]+$"
     local tag
     tag=$(grep -E "^$re$" "$tags" | sort -rV | head -n 1)
-    if [ -z "$tag" ] ; then
+    if [ -z "$tag" ]; then
         echo >&2 "WARNING: Could not find a matching tags for version '$ver'"
-        echo "$ver"
-        return
+        echo >&2 "ERROR: Tag for version '$ver' could not be resolved"
+        exit 1
     fi
     echo "$tag"
 }


### PR DESCRIPTION
## Summary
- restrict scanner release script RC tag regex to -rc.N format
- exit with error when no matching RC tag is found, retaining warning message

## Testing
- `shellcheck .github/workflows/scripts/scanner-output-release-versions.sh`


------
https://chatgpt.com/codex/tasks/task_e_68acf5a8a534832a92a87a435825c5f6